### PR TITLE
Batch with the same `last_published_updated_at` 

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.7.2
+  RUBY_VERSION: 2.6
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
   POSTGRES_DB: postgres

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,5 @@
 env:
-  RUBY_VERSION: 2.6
+  RUBY_VERSION: 2.7.2
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
   POSTGRES_DB: postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,5 @@
+## v0.1.1 (2021-08-11) - 
+* [#12](https://github.com/perryqh/db_blaster/pull/12/files) Fixing record query to include all results
+
 ## v0.1.0 (2021-07-27)
 * First release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    db_blaster (0.1.0)
+    db_blaster (0.1.1)
       aws-sdk-sns
       rails
 
@@ -78,14 +78,14 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     aws-eventstream (1.1.1)
-    aws-partitions (1.480.0)
-    aws-sdk-core (3.118.0)
+    aws-partitions (1.486.0)
+    aws-sdk-core (3.119.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-sns (1.43.0)
-      aws-sdk-core (~> 3, >= 3.118.0)
+    aws-sdk-sns (1.44.0)
+      aws-sdk-core (~> 3, >= 3.119.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.4)
       aws-eventstream (~> 1, >= 1.0.2)
@@ -121,7 +121,7 @@ GEM
       path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
       sexp_processor (~> 4.8)
-    globalid (0.5.1)
+    globalid (0.5.2)
       activesupport (>= 5.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -315,5 +315,3 @@ DEPENDENCIES
   shoulda-matchers
   simplecov
 
-BUNDLED WITH
-   2.2.24

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,24 +3,24 @@
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "6f4d3da0707c3f5f5c5bf5a002a254fee246210248aafa655cb2f15adfb47aa7",
+      "fingerprint": "3fef6d99f896e29ef9346d81a1557bd3819fbc762b2aa91d44dfa25a5c095485",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "lib/db_blaster/finder.rb",
-      "line": 38,
+      "line": 39,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "ActiveRecord::Base.connection.execute(\"#{select_sql} OFFSET #{offset}\")",
+      "code": "ActiveRecord::Base.connection.execute(\"#{FinderSql.sql_for_source_table(source_table)} OFFSET #{offset}\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "DbBlaster::Finder",
         "method": "find_records_in_batches"
       },
-      "user_input": "select_sql",
+      "user_input": "FinderSql.sql_for_source_table(source_table)",
       "confidence": "Medium",
-      "note": "No SQL injection can occur"
+      "note": "no sql injection"
     }
   ],
-  "updated": "2021-08-09 11:03:06 -0600",
+  "updated": "2021-08-11 13:14:00 -0600",
   "brakeman_version": "5.1.1"
 }

--- a/lib/db_blaster.rb
+++ b/lib/db_blaster.rb
@@ -11,6 +11,7 @@ require 'db_blaster/source_table_configuration_builder'
 require 'db_blaster/publisher'
 require 'db_blaster/publish_source_table'
 require 'db_blaster/chunker'
+require 'db_blaster/finder_sql'
 require 'db_blaster/finder'
 
 # Top-level module that serves as an entry point

--- a/lib/db_blaster/finder_sql.rb
+++ b/lib/db_blaster/finder_sql.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module DbBlaster
+  # Creates the SQL needed to find records for the provided source_table
+  class FinderSql
+    attr_reader :source_table
+
+    def initialize(source_table)
+      @source_table = source_table
+    end
+
+    def self.sql_for_source_table(source_table)
+      new(source_table).select_sql
+    end
+
+    def select_sql
+      "SELECT * FROM #{source_table.name} #{where} ORDER BY updated_at ASC LIMIT #{source_table.batch_size}"
+    end
+
+    def where
+      return '' unless from_updated_at
+
+      ActiveRecord::Base.sanitize_sql_for_conditions(
+        ['WHERE updated_at >= :updated_at', { updated_at: from_updated_at.to_s(:db) }]
+      )
+    end
+
+    def from_updated_at
+      @from_updated_at ||= source_table.last_published_updated_at
+    end
+  end
+end

--- a/lib/db_blaster/version.rb
+++ b/lib/db_blaster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DbBlaster
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/lib/db_blaster/finder_sql_spec.rb
+++ b/spec/lib/db_blaster/finder_sql_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe DbBlaster::FinderSql do
@@ -5,9 +7,9 @@ RSpec.describe DbBlaster::FinderSql do
 
   let!(:source_table) do
     create(:db_blaster_source_table, name: name,
-           batch_size: batch_size,
-           ignored_columns: ['ignored_columns'],
-           last_published_updated_at: last_published_updated_at)
+                                     batch_size: batch_size,
+                                     ignored_columns: ['ignored_columns'],
+                                     last_published_updated_at: last_published_updated_at)
   end
   let(:batch_size) { 10 }
   let(:name) { 'mountains' }
@@ -23,7 +25,7 @@ RSpec.describe DbBlaster::FinderSql do
     end
 
     context 'when last_published_updated_at set' do
-      let(:last_published_updated_at) { Time.now }
+      let(:last_published_updated_at) { Time.zone.now }
       let(:expected_sql) do
         "SELECT * FROM #{source_table.name} WHERE updated_at >= '#{source_table.reload.last_published_updated_at.to_s(:db)}' ORDER BY updated_at ASC LIMIT #{source_table.batch_size}"
       end

--- a/spec/lib/db_blaster/finder_sql_spec.rb
+++ b/spec/lib/db_blaster/finder_sql_spec.rb
@@ -27,7 +27,9 @@ RSpec.describe DbBlaster::FinderSql do
     context 'when last_published_updated_at set' do
       let(:last_published_updated_at) { Time.zone.now }
       let(:expected_sql) do
-        "SELECT * FROM #{source_table.name} WHERE updated_at >= '#{source_table.reload.last_published_updated_at.to_s(:db)}' ORDER BY updated_at ASC LIMIT #{source_table.batch_size}"
+        where = "WHERE updated_at >= '#{source_table.reload.last_published_updated_at.to_s(:db)}'"
+        limit = "LIMIT #{source_table.batch_size}"
+        "SELECT * FROM #{source_table.name} #{where} ORDER BY updated_at ASC #{limit}"
       end
 
       its(:select_sql) { is_expected.to eq(expected_sql) }

--- a/spec/lib/db_blaster/finder_sql_spec.rb
+++ b/spec/lib/db_blaster/finder_sql_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe DbBlaster::FinderSql do
+  subject(:finder_sql) { described_class.new(source_table) }
+
+  let!(:source_table) do
+    create(:db_blaster_source_table, name: name,
+           batch_size: batch_size,
+           ignored_columns: ['ignored_columns'],
+           last_published_updated_at: last_published_updated_at)
+  end
+  let(:batch_size) { 10 }
+  let(:name) { 'mountains' }
+  let(:last_published_updated_at) { nil }
+
+  describe '#select_sql' do
+    context 'when last_published_updated_at not set' do
+      let(:expected_sql) do
+        "SELECT * FROM #{source_table.name}  ORDER BY updated_at ASC LIMIT #{source_table.batch_size}"
+      end
+
+      its(:select_sql) { is_expected.to eq(expected_sql) }
+    end
+
+    context 'when last_published_updated_at set' do
+      let(:last_published_updated_at) { Time.now }
+      let(:expected_sql) do
+        "SELECT * FROM #{source_table.name} WHERE updated_at >= '#{source_table.reload.last_published_updated_at.to_s(:db)}' ORDER BY updated_at ASC LIMIT #{source_table.batch_size}"
+      end
+
+      its(:select_sql) { is_expected.to eq(expected_sql) }
+    end
+  end
+end


### PR DESCRIPTION
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/perryqh/be2fa5413124206272dbc700f3201f5a/raw/db_blaster__fix-from-updated-at.json)

# Description
Every time we queried, we were using the most recent `last_published_updated_at` AND offsetting. This fix keeps the same `last_published_updated_at` throughout

## Checklist

* [x] I have performed a self-review of my own code
