### PR TITLE
inlining s3-meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.1.5 (2021-09-02) -
+* [#22](https://github.com/perryqh/db_blaster/pull/22/files) Inline meta so that Spark can infer schema
+
 ## v0.1.4 (2021-09-01) -
 * [#21](https://github.com/perryqh/db_blaster/pull/21/files) Adding s3 tags option
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    db_blaster (0.1.4)
+    db_blaster (0.1.5)
       aws-sdk-s3
       aws-sdk-sns
       rails

--- a/lib/db_blaster/configuration.rb
+++ b/lib/db_blaster/configuration.rb
@@ -32,8 +32,7 @@ module DbBlaster
     # Applicable only when `s3_bucket' is set
     # The value set here will be included in every payload pushed to S3
     # example: config.s3_meta = {'infra_id' => '061', 'source_app' => 'kcp-api'}}
-    # The resulting JSON:
-    # {"meta" : {"infra_id" : "061", "src_app" : "kcp-api", "src_table" : "the-table"}, "records" : [] }
+    # The resulting JSON will include the `meta` merged into every record
     attr_accessor :s3_meta
 
     # Optional

--- a/lib/db_blaster/s3_publisher.rb
+++ b/lib/db_blaster/s3_publisher.rb
@@ -14,8 +14,7 @@ module DbBlaster
     end
 
     def content
-      { meta: meta,
-        records: records }
+      meta_records
     end
 
     def tagging
@@ -28,7 +27,11 @@ module DbBlaster
     end
 
     def meta
-      (DbBlaster.configuration.s3_meta.presence || {}).merge(source_table: source_table.name)
+      @meta ||= (DbBlaster.configuration.s3_meta.presence || {}).merge(source_table: source_table.name)
+    end
+
+    def meta_records
+      records.collect { |record| record.merge(meta) }
     end
 
     def client

--- a/lib/db_blaster/version.rb
+++ b/lib/db_blaster/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DbBlaster
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end

--- a/lib/generators/db_blaster/install/templates/db_blaster_config.rb
+++ b/lib/generators/db_blaster/install/templates/db_blaster_config.rb
@@ -32,8 +32,7 @@ DbBlaster.configure do |config|
   # Applicable only when `s3_bucket' is set
   # Extra meta values sent along with each payload
   # example: config.s3_meta = {'infra_id' => '061'}
-  # The resulting JSON:
-  # {"meta" : {"infra_id" : "061", "source_app" : "kcp-api", "src_table" : "the-table"}, "records" : [] }
+  # The resulting JSON will include the `meta` merged into every record.
   # config.s3_meta = {'infra_id' => '061'}
 
   # Optional

--- a/spec/lib/db_blaster/s3_publisher_spec.rb
+++ b/spec/lib/db_blaster/s3_publisher_spec.rb
@@ -56,17 +56,17 @@ RSpec.describe DbBlaster::S3Publisher do
     it 'delegates to S3KeyBuilder for key' do
       publish
       expect(DbBlaster::S3KeyBuilder).to have_received(:build)
-                                           .with(source_table_name: source_table.name,
-                                                 batch_start_time: batch_start_time)
+        .with(source_table_name: source_table.name,
+              batch_start_time: batch_start_time)
     end
 
     it 'publishes' do
       publish
       expect(client).to have_received(:put_object)
-                          .with(bucket: s3_bucket,
-                                key: key,
-                                body: expected_body,
-                                tagging: expected_tagging)
+        .with(bucket: s3_bucket,
+              key: key,
+              body: expected_body,
+              tagging: expected_tagging)
     end
 
     context 'with s3_meta and tags' do
@@ -85,10 +85,10 @@ RSpec.describe DbBlaster::S3Publisher do
       it 'publishes meta' do
         publish
         expect(client).to have_received(:put_object)
-                            .with(bucket: s3_bucket,
-                                  key: key,
-                                  body: expected_body,
-                                  tagging: expected_tagging)
+          .with(bucket: s3_bucket,
+                key: key,
+                body: expected_body,
+                tagging: expected_tagging)
       end
     end
   end


### PR DESCRIPTION
![Coverage Badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/perryqh/be2fa5413124206272dbc700f3201f5a/raw/db_blaster__inline-meta.json)

# Description
Though it's possible to "explode" nested arrays within Spark, we lose the ability to infer schema.
This change changes the S3 format to a simple JSON array

## Checklist

* [ ] I have performed a self-review of my own code
